### PR TITLE
feat: migrate syntax highlighting from Prism to Shiki

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @quicksilversel

--- a/articles/articles/frontend/mdx-syntax-highlighting-prism.mdx
+++ b/articles/articles/frontend/mdx-syntax-highlighting-prism.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Adding Syntax Highlighting to MDX with Prism and Next.js'
-description: 'Adding syntax highlighting to an MDX blog using Prism, Next.js, and TypeScript — fast, minimal, and clean.'
+description: 'Adding syntax highlighting to an MDX blog using Prism, Next.js, and TypeScript. Fast, minimal, and clean.'
 topics: ['prism', 'mdx']
 published: true
 date: '2024-07-15'

--- a/articles/articles/frontend/migrating-syntax-highlighting-prism-to-shiki.mdx
+++ b/articles/articles/frontend/migrating-syntax-highlighting-prism-to-shiki.mdx
@@ -1,0 +1,188 @@
+---
+title: 'Migrating Syntax Highlighting from Prism to Shiki'
+description: 'Why I replaced prism-react-renderer with shiki for code highlighting in my Next.js blog, and how the migration went.'
+topics: ['shiki', 'mdx']
+published: true
+date: '2026-04-15'
+---
+
+## Why Switch?
+
+I wrote about [setting up Prism](/articles/frontend/mdx-syntax-highlighting-prism) a while back. It worked well. `prism-react-renderer` is simple to set up and gets the job done. But after using it for a while, I started noticing places where the highlighting was off. TypeScript generics would sometimes confuse the tokenizer, and JSX mixed with complex expressions didn't always come out right.
+
+Prism uses regex-based tokenization. It works for most cases, but regex has limits, especially with nested syntax like TypeScript's type system or embedded expressions in JSX.
+
+[Shiki](https://shiki.matsu.io/) uses the same TextMate grammars that power VS Code. The highlighting is noticeably more accurate, and you get access to VS Code's entire theme ecosystem.
+
+## Dependencies
+
+Versions used when this was written:
+
+- [Next.js](https://nextjs.org/): 16.2.3
+- [shiki](https://shiki.matsu.io/): 4.0.2
+- [React](https://react.dev/): 19.2.3
+- [react-markdown](https://github.com/remarkjs/react-markdown): 10.1.0
+
+## Install
+
+```bash
+npm install shiki
+npm uninstall prism-react-renderer
+```
+
+## The Async Problem
+
+Shiki's main API is async. It needs to load grammars and themes before it can highlight anything. That doesn't play well with `react-markdown`, which renders components synchronously through its `components` prop.
+
+There are a few ways around this:
+
+1. Use `@shikijs/rehype` as a rehype plugin (but `react-markdown` calls `processSync` internally)
+2. Pre-process markdown on the server before passing it to the renderer
+3. Use shiki's synchronous core API with bundled grammars
+
+I went with option 3. Shiki provides `createHighlighterCoreSync` which lets you import grammars as JavaScript modules and create a highlighter that works synchronously. No WASM, no async initialization.
+
+## Highlighter Setup
+
+Created a module that initializes a sync highlighter with the languages I use on this blog:
+
+```ts
+import { createHighlighterCoreSync } from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+import githubDark from 'shiki/themes/github-dark.mjs'
+import langBash from 'shiki/langs/bash.mjs'
+import langCss from 'shiki/langs/css.mjs'
+import langDiff from 'shiki/langs/diff.mjs'
+import langHtml from 'shiki/langs/html.mjs'
+import langJavascript from 'shiki/langs/javascript.mjs'
+import langJson from 'shiki/langs/json.mjs'
+import langJsx from 'shiki/langs/jsx.mjs'
+import langMarkdown from 'shiki/langs/markdown.mjs'
+import langTsx from 'shiki/langs/tsx.mjs'
+import langTypescript from 'shiki/langs/typescript.mjs'
+import langYaml from 'shiki/langs/yaml.mjs'
+
+const highlighter = createHighlighterCoreSync({
+  themes: [githubDark],
+  langs: [
+    langBash,
+    langCss,
+    langDiff,
+    langHtml,
+    langJavascript,
+    langJson,
+    langJsx,
+    langMarkdown,
+    langTsx,
+    langTypescript,
+    langYaml,
+  ],
+  engine: createJavaScriptRegexEngine(),
+})
+
+export function highlightCode(code: string, lang: string) {
+  try {
+    return highlighter.codeToTokensBase(code, {
+      lang,
+      theme: 'github-dark',
+    })
+  } catch {
+    return highlighter.codeToTokensBase(code, {
+      lang: 'plaintext',
+      theme: 'github-dark',
+    })
+  }
+}
+```
+
+A few things worth noting:
+
+- **`createJavaScriptRegexEngine`** uses a pure JS regex engine instead of Oniguruma (WASM). It's lighter and works synchronously. For blog code blocks, the accuracy difference is negligible.
+- **Language imports use `.mjs`**. These are pre-compiled grammar bundles that can be imported synchronously.
+- **The try/catch** handles cases where a code block specifies a language I haven't loaded. It falls back to plain text instead of crashing.
+
+## Updating the Component
+
+The previous version used Prism's `Highlight` render prop to tokenize code. Shiki's `codeToTokensBase` returns a similar structure, an array of lines, where each line is an array of tokens with `content` and `color` properties.
+
+The component interface stays the same. It still receives a `<pre>` element from `react-markdown` with a `<code>` child:
+
+```tsx
+import { highlightCode } from '@/libs/shiki'
+
+export const HighlightedCode = ({ children }: Props) => {
+  const [copied, setCopied] = useState(false)
+
+  const codeElement = isValidElement<CodeProps>(children) ? children : null
+  const codeContent = codeElement?.props.children
+  const code = typeof codeContent === 'string' ? codeContent.trim() : ''
+  const language =
+    codeElement?.props.className?.replace('language-', '').trim() || 'text'
+
+  const tokens = useMemo(
+    () => (code ? highlightCode(code, language) : []),
+    [code, language],
+  )
+
+  if (!code) return null
+
+  return (
+    <CodeContainer>
+      <CopyButton onClick={handleCopy} title={copied ? 'Copied!' : 'Copy code'}>
+        {copied ? <ClipboardCheck /> : <Clipboard />}
+      </CopyButton>
+      <Pre>
+        <CodeWrapper>
+          {tokens.map((line, lineIndex) => (
+            <Line key={`line-${lineIndex}`}>
+              <LineNumber>{lineIndex + 1}</LineNumber>
+              <LineContent>
+                {line.map((token, tokenIndex) => (
+                  <span
+                    key={`token-${tokenIndex}`}
+                    style={{
+                      color: token.color,
+                      fontStyle: token.fontStyle === 1 ? 'italic' : undefined,
+                    }}
+                  >
+                    {token.content}
+                  </span>
+                ))}
+              </LineContent>
+            </Line>
+          ))}
+        </CodeWrapper>
+      </Pre>
+    </CodeContainer>
+  )
+}
+```
+
+### What Changed
+
+- Replaced `Highlight` from `prism-react-renderer` with `highlightCode` from the shiki utility
+- Token rendering maps `token.color` and `token.fontStyle` directly instead of using Prism's `getTokenProps`
+- Wrapped tokenization in `useMemo` to avoid re-tokenizing on copy button clicks
+- Validation logic moved before hooks to keep the rules of hooks happy, so there are no early returns before `useMemo`
+
+### What Didn't Change
+
+- The component still receives `<pre>` from `react-markdown`'s component mapping
+- Line numbers, copy button, and all styled components stayed the same
+- The `MarkdownRenderer` didn't need any changes at all
+
+## Prism vs Shiki
+
+|                | Prism                              | Shiki                                 |
+| -------------- | ---------------------------------- | ------------------------------------- |
+| Grammar system | Regex-based                        | TextMate (same as VS Code)            |
+| Themes         | Limited built-in set               | Full VS Code theme ecosystem          |
+| Accuracy       | Good for common cases              | Handles edge cases better             |
+| API            | Render prop (sync)                 | `codeToTokensBase` / `codeToHtml`     |
+| Bundle         | Included in `prism-react-renderer` | Language grammars loaded per-language |
+
+## Final Notes
+
+The migration was straightforward, just one utility file and an updated component. No changes to the markdown pipeline or rendering setup. The code blocks on this blog now use GitHub Dark theme colors with TextMate-grade tokenization, which is a nice upgrade from Prism's defaults.
+
+If you're using `react-markdown` and need synchronous highlighting, the `createHighlighterCoreSync` + `createJavaScriptRegexEngine` combo is the way to go. It avoids the async initialization dance entirely while still giving you shiki's grammar quality.

--- a/articles/articles/frontend/msw-v1-to-v2-migration-jest-setup.mdx
+++ b/articles/articles/frontend/msw-v1-to-v2-migration-jest-setup.mdx
@@ -1,0 +1,261 @@
+---
+title: 'MSW v1 to v2: The Jest Setup Nobody Warns You About'
+description: 'Migrating MSW from v1 to v2 sounds straightforward until your test suite explodes. A walkthrough of the polyfills, fetch replacements, and config changes needed to make Jest work with MSW v2.'
+date: 2026-04-14
+topics: ['MSW', 'Jest', 'Next.js']
+published: true
+---
+
+## It Started Simple
+
+The [MSW v2 migration guide](https://mswjs.io/docs/migrations/1.x-to-2.x/) is well-written. It walks you through the API changes: `rest` becomes `http`, `res(ctx.json(data))` becomes `HttpResponse.json(data)`, types get renamed. Straightforward stuff. I read through it, thought "this won't take long," and started updating handler files.
+
+The handler changes were indeed mechanical. But when I ran `npm test`, everything fell apart. Not because of the API changes — because of what MSW v2 now expects from the environment it runs in.
+
+## The Handler Changes (The Easy Part)
+
+Before diving into the hard stuff, here's what the handler migration looks like. This part is genuinely simple:
+
+```ts
+// v1
+import { rest } from 'msw'
+import type { ResponseResolver, RestRequest, RestContext } from 'msw'
+
+export const handler = rest.get('/api/items', resolve)
+
+export const resolve: ResponseResolver<RestRequest, RestContext> = (
+  req,
+  res,
+  ctx,
+) => {
+  const limit = Number(req.url.searchParams.get('limit'))
+  return res(ctx.json({ items: [], limit }))
+}
+```
+
+```ts
+// v2
+import { http, HttpResponse } from 'msw'
+import type { HttpResponseResolver } from 'msw'
+
+export const handler = http.get('/api/items', resolve)
+
+export const resolve: HttpResponseResolver = ({ request }) => {
+  const url = new URL(request.url)
+  const limit = Number(url.searchParams.get('limit'))
+  return HttpResponse.json({ items: [], limit })
+}
+```
+
+The pattern is consistent across every handler: `rest` → `http`, the three-argument callback `(req, res, ctx)` becomes a single destructured object `({ request })`, and `res(ctx.json())` becomes `HttpResponse.json()`. For network errors, `res.networkError('Failed')` becomes `HttpResponse.error()`. For passthrough requests, `req.passthrough()` becomes the `passthrough()` function imported from `msw`.
+
+Other small changes:
+
+- `setupWorker` import moves from `msw` to `msw/browser`
+- `RequestHandler` type becomes `HttpHandler`
+- URL params are accessed via `new URL(request.url)` instead of `req.url.searchParams`
+
+If this was all there was to it, the migration would take an hour. But it wasn't.
+
+## The Real Problem: jsdom Doesn't Have Web APIs
+
+MSW v2 is built on web standards. It uses `TextEncoder`, `TextDecoder`, `ReadableStream`, `WritableStream`, `TransformStream`, and `BroadcastChannel` internally. These are all available in modern browsers and Node.js — but not in jsdom.
+
+Jest with jsdom is the standard setup for testing React components. jsdom simulates a browser environment, but it doesn't implement every Web API. MSW v1 worked around this by using Node.js-specific polyfills internally. MSW v2 dropped that approach and expects these APIs to exist globally.
+
+The first error I hit was something like:
+
+```
+ReferenceError: TextEncoder is not defined
+```
+
+The fix is to polyfill everything MSW v2 needs in `jest/setup.ts`, before any other imports:
+
+```ts
+import { TransformStream, ReadableStream, WritableStream } from 'stream/web'
+import { TextEncoder, TextDecoder } from 'util'
+import { BroadcastChannel } from 'worker_threads'
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder
+}
+if (typeof globalThis.TransformStream === 'undefined') {
+  globalThis.TransformStream =
+    TransformStream as typeof globalThis.TransformStream
+}
+if (typeof globalThis.ReadableStream === 'undefined') {
+  globalThis.ReadableStream = ReadableStream as typeof globalThis.ReadableStream
+}
+if (typeof globalThis.WritableStream === 'undefined') {
+  globalThis.WritableStream = WritableStream as typeof globalThis.WritableStream
+}
+if (typeof globalThis.BroadcastChannel === 'undefined') {
+  globalThis.BroadcastChannel =
+    BroadcastChannel as typeof globalThis.BroadcastChannel
+}
+```
+
+The `typeof` checks aren't strictly necessary in jsdom (they'll always be undefined), but they make the setup defensive — if a future jsdom version adds support, you won't get conflicts.
+
+The order matters here. These polyfills must come before `@testing-library/jest-dom` or any other import that might trigger MSW initialization.
+
+## Replacing whatwg-fetch with undici
+
+After fixing the Web API polyfills, I hit the next wall. Our setup was using `whatwg-fetch` to polyfill the Fetch API in jsdom:
+
+```ts
+// Before
+if (typeof window !== 'undefined') {
+  require('whatwg-fetch')
+}
+```
+
+This worked fine with MSW v1, but MSW v2's `HttpResponse.error()` creates a `Response` with status `0` — a network error response. `whatwg-fetch`'s `Response` implementation doesn't handle this correctly and throws.
+
+The fix is to use `undici`, which is the HTTP client that Node.js uses internally for its native `fetch`. Since it's the same implementation, it handles all edge cases correctly:
+
+```ts
+if (typeof window !== 'undefined') {
+  const undici = require('undici')
+  globalThis.fetch = undici.fetch
+  globalThis.Response = undici.Response
+  globalThis.Request = undici.Request
+  globalThis.Headers = undici.Headers
+}
+```
+
+This swap means replacing `whatwg-fetch` with `undici` in `devDependencies` too:
+
+```diff
+- "whatwg-fetch": "^3.6.2"
++ "undici": "^5.28.4"
+```
+
+## The Jest Config Changes
+
+Even after the polyfills, tests were failing with import errors. MSW v2 depends on packages like `rettime` and `until-async` that ship as ESM-only. Jest's default `transformIgnorePatterns` skips everything in `node_modules/`, so these ESM packages don't get transformed and fail to import.
+
+I was already handling a few ESM packages, but the approach needed restructuring:
+
+```ts
+// Before
+const esm = ['@example/icons', '@example/components', 'swiper']
+
+// ...
+const getConfig = async (): Promise<Config> => {
+  const jestConfig = await createJestConfig(config)()
+  return {
+    ...jestConfig,
+    transformIgnorePatterns:
+      jestConfig.transformIgnorePatterns?.filter(
+        (pattern: string | RegExp) => pattern !== '/node_modules/',
+      ) ?? [],
+  }
+}
+```
+
+The old approach just removed the `/node_modules/` pattern entirely, which meant Jest would try to transform everything in `node_modules/`. This worked but was slow. The new approach explicitly lists which packages to transform:
+
+```ts
+const esm = [
+  '@example/icons',
+  '@example/components',
+  'swiper',
+  'rettime',
+  'until-async',
+]
+
+const getConfig = async (): Promise<Config> => {
+  const jestConfig = await createJestConfig(config)()
+  return {
+    ...jestConfig,
+    transformIgnorePatterns: [
+      `/node_modules/(?!(${esm.join('|')})/)`,
+      ...(jestConfig.transformIgnorePatterns?.filter(
+        (pattern: string | RegExp) =>
+          typeof pattern === 'string' && !pattern.includes('/node_modules/'),
+      ) ?? []),
+    ],
+    testEnvironmentOptions: {
+      ...jestConfig.testEnvironmentOptions,
+      customExportConditions: ['node', 'node-addons'],
+    },
+  }
+}
+```
+
+Two changes here:
+
+1. **`transformIgnorePatterns`** now uses a negative lookahead regex to only transform the listed ESM packages, instead of removing the `node_modules` exclusion entirely.
+
+2. **`customExportConditions`** is new and critical. MSW v2 uses the `exports` field in `package.json` with conditional exports. Without `['node', 'node-addons']`, Jest resolves the wrong entry point and you get cryptic import errors.
+
+## The Storybook Side
+
+If you use `msw-storybook-addon`, it needs to be upgraded too:
+
+```diff
+- "msw-storybook-addon": "^1.8.0"
++ "msw-storybook-addon": "^2.0.7"
+```
+
+And the handler syntax in stories follows the same v1 → v2 pattern:
+
+```ts
+// v1
+import { rest } from 'msw'
+
+parameters: {
+  msw: {
+    handlers: [
+      rest.get('/api/stock', (_, res, ctx) => {
+        return res(ctx.json({ stock: 10 }))
+      }),
+    ],
+  },
+}
+```
+
+```ts
+// v2
+import { http, HttpResponse } from 'msw'
+
+parameters: {
+  msw: {
+    handlers: [
+      http.get('/api/stock', () => {
+        return HttpResponse.json({ stock: 10 })
+      }),
+    ],
+  },
+}
+```
+
+Don't forget to regenerate `mockServiceWorker.js` with `npx msw init public/` — the service worker file changed significantly between v1 and v2.
+
+## The Full Checklist
+
+If you're doing this migration in a Next.js + Jest project, here's everything in order:
+
+1. Update `msw` to v2 and `msw-storybook-addon` to v2 (if applicable)
+2. Replace `whatwg-fetch` with `undici` in devDependencies
+3. Add Web API polyfills to your Jest setup file (before other imports)
+4. Replace `whatwg-fetch` with `undici`'s fetch/Response/Request/Headers in the setup
+5. Add `rettime` and `until-async` to your ESM transform list
+6. Add `customExportConditions: ['node', 'node-addons']` to `testEnvironmentOptions`
+7. Update all handlers: `rest` → `http`, `res(ctx.*)` → `HttpResponse.*`
+8. Update types: `ResponseResolver<RestRequest, RestContext>` → `HttpResponseResolver`, `RequestHandler` → `HttpHandler`
+9. Update `setupWorker` import from `msw` to `msw/browser`
+10. Regenerate `mockServiceWorker.js`
+11. Run tests, fix any remaining issues
+
+## What I'd Do Differently
+
+If I could redo this, I'd start with the Jest setup changes (steps 2-6) before touching any handler code. The handler changes are mechanical and easy to verify — but if your test environment isn't set up correctly, every test fails and you can't tell if your handler changes are correct.
+
+I spent time debugging handler code that was actually fine. The tests were failing because of missing polyfills, not because of incorrect handler syntax.
+
+The MSW migration guide focuses on the API changes because that's what MSW controls. The Jest environment setup is technically Jest's problem, not MSW's. But in practice, it's the part that takes the most time and causes the most confusion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,12 @@
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.544.0",
         "next": "^16.2.3",
-        "prism-react-renderer": "^2.3.1",
         "react": "^19",
         "react-dom": "^19",
         "react-markdown": "^10.1.0",
         "reading-time": "^1.5.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "shiki": "^4.0.2"
       },
       "devDependencies": {
         "@types/node": "^24",
@@ -2123,6 +2123,106 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2226,12 +2326,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/prismjs": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
-      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -3484,15 +3578,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5527,6 +5612,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -5637,6 +5745,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -7733,6 +7851,23 @@
         "wrappy": "1"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8070,19 +8205,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prism-react-renderer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
-      "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prismjs": "^1.26.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -8249,6 +8371,30 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -8659,6 +8805,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.544.0",
     "next": "^16.2.3",
-    "prism-react-renderer": "^2.3.1",
     "react": "^19",
     "react-dom": "^19",
     "react-markdown": "^10.1.0",
     "reading-time": "^1.5.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "shiki": "^4.0.2"
   },
   "devDependencies": {
     "@types/node": "^24",

--- a/src/components/Pages/Article/ArticleDetail/Markup/HighlightedCode/HighlightedCode.tsx
+++ b/src/components/Pages/Article/ArticleDetail/Markup/HighlightedCode/HighlightedCode.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { ReactNode, isValidElement, useState } from 'react'
+import { ReactNode, isValidElement, useMemo, useState } from 'react'
 
 import styled from '@emotion/styled'
 import { Clipboard, ClipboardCheck } from 'lucide-react'
-import { Highlight } from 'prism-react-renderer'
+
+import { highlightCode } from '@/libs/shiki'
 
 type Props = {
   children?: ReactNode
@@ -18,21 +19,18 @@ type CodeProps = {
 export const HighlightedCode = ({ children }: Props) => {
   const [copied, setCopied] = useState(false)
 
-  if (!isValidElement<CodeProps>(children)) {
-    return null
-  }
+  const codeElement = isValidElement<CodeProps>(children) ? children : null
+  const codeContent = codeElement?.props.children
+  const code = typeof codeContent === 'string' ? codeContent.trim() : ''
+  const language =
+    codeElement?.props.className?.replace('language-', '').trim() || 'text'
 
-  const codeContent = children.props.children
-  if (typeof codeContent !== 'string') {
-    return null
-  }
-
-  const code = codeContent.trim()
+  const tokens = useMemo(
+    () => (code ? highlightCode(code, language) : []),
+    [code, language],
+  )
 
   if (!code) return null
-
-  const language =
-    children.props.className?.replace('language-', '').trim() || 'text'
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(code)
@@ -41,36 +39,33 @@ export const HighlightedCode = ({ children }: Props) => {
   }
 
   return (
-    <Highlight code={code} language={language}>
-      {({ tokens, getLineProps, getTokenProps }) => (
-        <CodeContainer>
-          <CopyButton
-            onClick={handleCopy}
-            title={copied ? 'Copied!' : 'Copy code'}
-          >
-            {copied ? <ClipboardCheck /> : <Clipboard />}
-          </CopyButton>
-          <Pre>
-            <CodeWrapper>
-              {tokens.map((line, index) => (
-                <Line key={`token-${index}`} {...getLineProps({ line })}>
-                  <LineNumber>{index + 1}</LineNumber>
-                  <LineContent>
-                    {line.map((token, index) => (
-                      <span
-                        key={`line-${index}`}
-                        {...getTokenProps({ token })}
-                      />
-                    ))}
-                    {line.length === 0 && '\n'}
-                  </LineContent>
-                </Line>
-              ))}
-            </CodeWrapper>
-          </Pre>
-        </CodeContainer>
-      )}
-    </Highlight>
+    <CodeContainer>
+      <CopyButton onClick={handleCopy} title={copied ? 'Copied!' : 'Copy code'}>
+        {copied ? <ClipboardCheck /> : <Clipboard />}
+      </CopyButton>
+      <Pre>
+        <CodeWrapper>
+          {tokens.map((line, lineIndex) => (
+            <Line key={`line-${lineIndex}`}>
+              <LineNumber>{lineIndex + 1}</LineNumber>
+              <LineContent>
+                {line.map((token, tokenIndex) => (
+                  <span
+                    key={`token-${tokenIndex}`}
+                    style={{
+                      color: token.color,
+                      fontStyle: token.fontStyle === 1 ? 'italic' : undefined,
+                    }}
+                  >
+                    {token.content}
+                  </span>
+                ))}
+              </LineContent>
+            </Line>
+          ))}
+        </CodeWrapper>
+      </Pre>
+    </CodeContainer>
   )
 }
 

--- a/src/libs/shiki/index.ts
+++ b/src/libs/shiki/index.ts
@@ -1,0 +1,46 @@
+import { createHighlighterCoreSync } from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+import langBash from 'shiki/langs/bash.mjs'
+import langCss from 'shiki/langs/css.mjs'
+import langDiff from 'shiki/langs/diff.mjs'
+import langHtml from 'shiki/langs/html.mjs'
+import langJavascript from 'shiki/langs/javascript.mjs'
+import langJson from 'shiki/langs/json.mjs'
+import langJsx from 'shiki/langs/jsx.mjs'
+import langMarkdown from 'shiki/langs/markdown.mjs'
+import langTsx from 'shiki/langs/tsx.mjs'
+import langTypescript from 'shiki/langs/typescript.mjs'
+import langYaml from 'shiki/langs/yaml.mjs'
+import githubDark from 'shiki/themes/github-dark.mjs'
+
+const highlighter = createHighlighterCoreSync({
+  themes: [githubDark],
+  langs: [
+    langBash,
+    langCss,
+    langDiff,
+    langHtml,
+    langJavascript,
+    langJson,
+    langJsx,
+    langMarkdown,
+    langTsx,
+    langTypescript,
+    langYaml,
+  ],
+  engine: createJavaScriptRegexEngine(),
+})
+
+export function highlightCode(code: string, lang: string) {
+  try {
+    return highlighter.codeToTokensBase(code, {
+      lang,
+      theme: 'github-dark',
+    })
+  } catch {
+    return highlighter.codeToTokensBase(code, {
+      lang: 'plaintext',
+      theme: 'github-dark',
+    })
+  }
+}


### PR DESCRIPTION
- Added CODEOWNERS file to define code ownership.
- Updated MDX articles to improve descriptions and added a new article on migrating from Prism to Shiki.
- Replaced `prism-react-renderer` with `shiki` for code highlighting in HighlightedCode component.
- Implemented synchronous highlighter setup using Shiki's core API.
- Updated Jest setup to include necessary polyfills for MSW v2.
- Replaced `whatwg-fetch` with `undici` for Fetch API polyfills in Jest.
- Adjusted Jest config to handle ESM packages and custom export conditions.